### PR TITLE
Fix query containing array

### DIFF
--- a/src/AbstractPaginator.php
+++ b/src/AbstractPaginator.php
@@ -471,7 +471,7 @@ abstract class AbstractPaginator implements PaginatorInterface, ArrayAccess, Str
     /**
      * Add a query string value to the paginator.
      */
-    protected function addQuery(string $key, string $value): static
+    protected function addQuery(string $key, $value): static
     {
         if ($key !== $this->pageName) {
             $this->query[$key] = $value;


### PR DESCRIPTION
### Fixed
* 修复请求 url 的参数中含有数组格式时，调用 builder->paginate 方法时构建分页 link 的 addQuery 会出现报错。比如 https://abc.com?a[]=1&a[]=2&a[]=3&page=1